### PR TITLE
feat(web): show site and app version in the footer

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,7 +1,9 @@
 //! WebAssembly bindings for the long-multiplication calculator.
 //!
-//! Exposes a single [`calculate`] function that mirrors the CLI:
-//! take two digit strings, return the Unicode table.
+//! Exposes the same primitives the CLI uses: [`calculate`] takes two
+//! digit strings and returns the Unicode table, [`max_digits`]
+//! reports the upper bound, and [`version`] returns the
+//! `CARGO_PKG_VERSION` baked into the binary.
 
 use long_multiplication_core::{MAX_DIGITS, get_table, validate_input};
 use wasm_bindgen::prelude::*;
@@ -38,6 +40,28 @@ pub fn calculate(multiplicand: &str, multiplier: &str) -> Result<String, JsError
 #[wasm_bindgen(js_name = maxDigits)]
 pub fn max_digits() -> usize {
     MAX_DIGITS
+}
+
+/// Semantic version of the compiled WASM module.
+///
+/// Sourced from `CARGO_PKG_VERSION` at build time, so it always
+/// matches the version in `Cargo.toml`. Exposed to JavaScript so
+/// the front end can show it in the footer and so a runtime check
+/// can confirm the binary that is actually executing matches the
+/// one the page expects.
+///
+/// # Examples
+///
+/// ```
+/// use long_multiplication_wasm::version;
+///
+/// // The string is the same one baked into Cargo.toml.
+/// assert_eq!(version(), env!("CARGO_PKG_VERSION"));
+/// assert!(!version().is_empty());
+/// ```
+#[wasm_bindgen]
+pub fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_owned()
 }
 
 #[cfg(test)]

--- a/web/asset/js/app.js
+++ b/web/asset/js/app.js
@@ -4,7 +4,7 @@
 // `calculate` function to the form. No network round-trips: every
 // computation happens in the browser.
 
-import init, { calculate } from './wasm/long_multiplication_wasm.js';
+import init, { calculate, version } from './wasm/long_multiplication_wasm.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -17,15 +17,26 @@ const copyBtn = $('copy');
 const status = $('status');
 const statusText = $('status-text');
 const solution = $('solution');
+const appVersion = $('app-version');
 
 const DIGIT_RE = /^[0-9]+$/;
 let lastResult = '';
 
-// Initialise WASM, then enable the form.
+// Initialise WASM, then enable the form and stamp the footer with
+// the actual binary version. The `<span id="app-version">` in
+// `index.html` ships empty on purpose: if WASM fails to load, we
+// would rather show nothing than a stale hardcoded number.
 (async () => {
     try {
         await init();
         calculateBtn.disabled = false;
+        if (appVersion) {
+            try {
+                appVersion.textContent = version();
+            } catch {
+                // If `version()` somehow throws, leave the span empty.
+            }
+        }
     } catch (err) {
         showError(`Failed to load the calculator: ${err?.message ?? err}`);
     }

--- a/web/index.html
+++ b/web/index.html
@@ -91,7 +91,9 @@
         <p>
             Author: <a href="https://github.com/airvzxf" target="_blank" rel="noopener noreferrer">Israel Alberto Roldan Vega</a>.<br>
             This project is under the <a href="https://www.gnu.org/licenses/agpl-3.0.html" rel="license">AGPL-3.0 License</a>.<br>
-            Source: <a href="https://github.com/airvzxf/long-multiplication-calculator" target="_blank" rel="noopener noreferrer">github.com/airvzxf/long-multiplication-calculator</a>.
+            Source: <a href="https://github.com/airvzxf/long-multiplication-calculator" target="_blank" rel="noopener noreferrer">github.com/airvzxf/long-multiplication-calculator</a>.<br>
+            Site version: 2.0.<br>
+            App version: <span id="app-version"></span>
         </p>
     </footer>
 </main>


### PR DESCRIPTION
Closes #7.

## What

The footer of `web/index.html` now shows two distinct versions that
measure different things:

- **Site version** (`2.0`), hardcoded in the HTML. Bumped manually
  when the HTML, CSS, or frontend JS changes.
- **App version**, sourced from `CARGO_PKG_VERSION` at compile time
  via a new `version()` binding in `long_multiplication_wasm`. The
  HTML ships an empty `<span id="app-version">` and `app.js` fills
  it on init; if WASM fails to load, the span stays empty rather
  than showing a stale hardcoded number.

## Why

A user reporting a bug needs to know which version they were
running. Splitting the two versions also makes it possible to tell
whether a user is looking at a stale cached page after a
frontend-only deploy vs. an old WASM binary.

## Changes

- `crates/wasm/src/lib.rs` — new `pub fn version() -> String`,
  exported with `#[wasm_bindgen]`, returning
  `env!("CARGO_PKG_VERSION")`. Documented with a doctest that pins
  it to `env!("CARGO_PKG_VERSION")`. Module docstring updated.
- `web/asset/js/app.js` — imports `version` and writes it into
  `#app-version` after `init()`.
- `web/index.html` — two new lines in the footer (site version +
  empty app-version span).

The CLI was already exposing `--version` via clap, so no change
was needed there.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (130 tests passing, including the new
  `version()` doctest)
- `cargo build --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit` (no advisories)
- `./scripts/build_wasm.bash` (41 KB optimised bundle)
- `wasm-pack test --chrome --headless crates/wasm` (1/1 in
  headless Chromium)

## Notes

- No CHANGELOG entry in this PR. The repo's existing convention
  ties entries to a real version; the changelog will be updated as
  part of the release commit when `Cargo.toml` is bumped to
  `2.2.0`.
- The site version number (`2.0`) is a deliberate match for the
  current `?v=2.0` cache-bust query on `styles.css` in the HTML.