### PR TITLE
feat(build): cache-bust the WASM glue with the package version

### DIFF
--- a/scripts/build_wasm.bash
+++ b/scripts/build_wasm.bash
@@ -11,6 +11,16 @@
 #      etc.) and wasm-pack's default `-O` invocation does not enable
 #      these features, so it fails validation.
 #
+# A third phase stamps the WASM package version (read from
+# Cargo.toml) as a `?v=<version>` cache-bust suffix on the two
+# files that reference the WASM glue: `web/asset/js/app.js` (the
+# import) and `web/index.html` (the modulepreload). The committed
+# source has the placeholder `?v=__WASM_VERSION__`; this script is
+# the only place that resolves it. The substitution is reverted on
+# EXIT so the working tree stays clean after a local build, and
+# the deploy workflow picks up the stamped files from the CI
+# runner's filesystem before wrangler uploads `web/`.
+#
 # Usage:
 #   ./scripts/build_wasm.bash         # optimised bundle (~25 KB)
 #   ./scripts/build_wasm.bash --no-opt  # skip wasm-opt (~45 KB)
@@ -31,6 +41,17 @@ fi
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${REPO_ROOT}/web/asset/js/wasm"
 WASM_FILE="${OUT_DIR}/long_multiplication_wasm_bg.wasm"
+
+# Read the workspace version from Cargo.toml. This becomes the
+# `?v=<version>` cache-bust suffix on the WASM glue references,
+# so the browser always re-fetches the glue (and its modulepreload)
+# whenever the package version changes.
+WASM_VERSION=$(grep -E '^version = ' "${REPO_ROOT}/Cargo.toml" | head -1 | sed -E 's/^version = "(.*)"/\1/')
+if [[ -z "${WASM_VERSION}" ]]; then
+    echo ">>> ERROR: could not read version from ${REPO_ROOT}/Cargo.toml" >&2
+    exit 1
+fi
+echo ">>> WASM version: ${WASM_VERSION}"
 
 echo ">>> Building WASM (target: web, release, out: ${OUT_DIR})"
 wasm-pack build \
@@ -54,6 +75,22 @@ elif command -v wasm-opt >/dev/null 2>&1; then
 else
     echo ">>> wasm-opt not found on \$PATH; bundle left unoptimised"
 fi
+
+# Stamp the cache-bust suffix into the two files that reference
+# the WASM glue. The committed source has `?v=__WASM_VERSION__`;
+# this is the only place it gets resolved to a real version.
+echo ">>> Stamping cache-bust: ?v=${WASM_VERSION}"
+sed -i "s|?v=__WASM_VERSION__|?v=${WASM_VERSION}|g" \
+    "${REPO_ROOT}/web/asset/js/app.js" \
+    "${REPO_ROOT}/web/index.html"
+
+# Always revert the stamp at exit (success or failure) so the
+# working tree is left in the committed state. The deploy runner
+# reads the stamped files before this trap fires, so `web/` is
+# still uploaded with the version baked in.
+trap 'sed -i "s|?v='"${WASM_VERSION}"'|?v=__WASM_VERSION__|g" \
+    "${REPO_ROOT}/web/asset/js/app.js" \
+    "${REPO_ROOT}/web/index.html"' EXIT
 
 echo ">>> Done. Files:"
 ls -lh "${OUT_DIR}"

--- a/web/asset/js/app.js
+++ b/web/asset/js/app.js
@@ -4,7 +4,7 @@
 // `calculate` function to the form. No network round-trips: every
 // computation happens in the browser.
 
-import init, { calculate, version } from './wasm/long_multiplication_wasm.js';
+import init, { calculate, version } from './wasm/long_multiplication_wasm.js?v=__WASM_VERSION__';
 
 const $ = (id) => document.getElementById(id);
 

--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
     <link href="/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">
     <link href="/site.manifest" rel="manifest">
     <link href="asset/css/styles.css?v=2.0" rel="stylesheet">
-    <link rel="modulepreload" href="asset/js/wasm/long_multiplication_wasm.js">
+    <link rel="modulepreload" href="asset/js/wasm/long_multiplication_wasm.js?v=__WASM_VERSION__">
 </head>
 <body>
 <main class="container">


### PR DESCRIPTION
Closes #9.

## What

Adds a `?v=<version>` cache-bust query string to the two places
in the web frontend that reference the WASM glue:

- `web/asset/js/app.js` (the import)
- `web/index.html` (the `<link rel="modulepreload">`)

The version is sourced from `Cargo.toml` and stamped in by
`scripts/build_wasm.bash`. The committed source has a
`?v=__WASM_VERSION__` placeholder; the build script is the
only place that resolves it. An `EXIT` trap reverts the stamp
so the working tree stays clean after a local build.

## Why

The custom domain `multiplication.rovisoft.net` is fronted by
a Cloudflare zone that caches responses with a long TTL and
does not get purged on every Pages deploy. After #7 landed,
`pages.dev` showed the new `version()` export but the custom
domain kept returning the old glue, so the import silently
failed and the footer showed no app version. This makes the
app resilient to any future cache layer (browser, Cloudflare
edge, ISP, server proxy) by ensuring the browser always
re-fetches the glue whenever the package version changes.

This is the same pattern as the existing `?v=2.0` on
`styles.css`, but version-driven and automatic.

## Changes

- `web/asset/js/app.js`: import URL gains
  `?v=__WASM_VERSION__`.
- `web/index.html`: modulepreload gains the same placeholder.
- `scripts/build_wasm.bash`: new step that reads `version` from
  `Cargo.toml`, stamps `?v=<version>` into both files after
  the `wasm-pack` build, and registers an `EXIT` trap to
  revert the stamp. The deploy workflow (CI) reads the stamped
  files before the trap fires, so the uploaded `web/` always
  has the right version while the repo stays committed with
  the placeholder.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (130/130 passing)
- `cargo build --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit` (no advisories)
- `./scripts/build_wasm.bash` — the new
  `>>> Stamping cache-bust: ?v=2.1.0` line fires, and the
  working tree reverts to the placeholder on EXIT (verified by
  re-running `git status` and `grep` on the stamped files).
- `wasm-pack test --chrome --headless crates/wasm` (1/1 in
  headless Chromium)

## Notes

- No CHANGELOG entry in this PR. Same convention as #7: the
  changelog is updated as part of the release commit when
  `Cargo.toml` is bumped.
- One purge of the Cloudflare edge cache for
  `multiplication.rovisoft.net` is still needed after this
  lands, so the currently-cached old glue is evicted. After
  that, every deploy is picked up automatically.
- The underlying zone-level cache rule on `rovisoft.net` is
  out of scope for this PR; the cache-bust makes the app
  resilient to it (and to any future cache layer) without
  requiring dashboard changes.