### PR TITLE
fix(build): keep the WASM cache-bust stamp alive until the deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y binaryen
 
       - name: Build optimised WASM into web/
-        run: ./scripts/build_wasm.bash
+        run: ./scripts/build_wasm.bash --no-revert
 
       - name: Publish to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/scripts/build_wasm.bash
+++ b/scripts/build_wasm.bash
@@ -16,14 +16,17 @@
 # files that reference the WASM glue: `web/asset/js/app.js` (the
 # import) and `web/index.html` (the modulepreload). The committed
 # source has the placeholder `?v=__WASM_VERSION__`; this script is
-# the only place that resolves it. The substitution is reverted on
-# EXIT so the working tree stays clean after a local build, and
-# the deploy workflow picks up the stamped files from the CI
-# runner's filesystem before wrangler uploads `web/`.
+# the only place that resolves it.
+#
+# By default, the stamp is reverted on EXIT so the working tree
+# stays clean after a local build. Pass `--no-revert` to keep the
+# stamp in place; the deploy workflow (CI) uses this so wrangler
+# uploads the version-baked files instead of the placeholder.
 #
 # Usage:
-#   ./scripts/build_wasm.bash         # optimised bundle (~25 KB)
-#   ./scripts/build_wasm.bash --no-opt  # skip wasm-opt (~45 KB)
+#   ./scripts/build_wasm.bash              # optimised, reverts stamp
+#   ./scripts/build_wasm.bash --no-opt     # skip wasm-opt
+#   ./scripts/build_wasm.bash --no-revert  # keep the stamp (CI)
 #
 # Requirements:
 #   * Rust with the `wasm32-unknown-unknown` target installed:
@@ -34,13 +37,26 @@
 set -euo pipefail
 
 SKIP_OPT=0
-if [[ "${1:-}" == "--no-opt" ]]; then
-    SKIP_OPT=1
-fi
+NO_REVERT=0
+for arg in "$@"; do
+    case "$arg" in
+        --no-opt) SKIP_OPT=1 ;;
+        --no-revert) NO_REVERT=1 ;;
+        -h|--help)
+            sed -n '2,35p' "${BASH_SOURCE[0]}"
+            exit 0
+            ;;
+        *) echo ">>> ERROR: unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${REPO_ROOT}/web/asset/js/wasm"
 WASM_FILE="${OUT_DIR}/long_multiplication_wasm_bg.wasm"
+STAMP_FILES=(
+    "${REPO_ROOT}/web/asset/js/app.js"
+    "${REPO_ROOT}/web/index.html"
+)
 
 # Read the workspace version from Cargo.toml. This becomes the
 # `?v=<version>` cache-bust suffix on the WASM glue references,
@@ -80,17 +96,18 @@ fi
 # the WASM glue. The committed source has `?v=__WASM_VERSION__`;
 # this is the only place it gets resolved to a real version.
 echo ">>> Stamping cache-bust: ?v=${WASM_VERSION}"
-sed -i "s|?v=__WASM_VERSION__|?v=${WASM_VERSION}|g" \
-    "${REPO_ROOT}/web/asset/js/app.js" \
-    "${REPO_ROOT}/web/index.html"
+sed -i "s|?v=__WASM_VERSION__|?v=${WASM_VERSION}|g" "${STAMP_FILES[@]}"
 
-# Always revert the stamp at exit (success or failure) so the
-# working tree is left in the committed state. The deploy runner
-# reads the stamped files before this trap fires, so `web/` is
-# still uploaded with the version baked in.
-trap 'sed -i "s|?v='"${WASM_VERSION}"'|?v=__WASM_VERSION__|g" \
-    "${REPO_ROOT}/web/asset/js/app.js" \
-    "${REPO_ROOT}/web/index.html"' EXIT
+# By default, revert the stamp at exit (success or failure) so the
+# working tree is left in the committed state for local builds.
+# `--no-revert` skips the trap so the stamped files survive until
+# the deploy step (wrangler pages deploy) reads them.
+if [[ "${NO_REVERT}" -eq 0 ]]; then
+    trap 'sed -i "s|?v='"${WASM_VERSION}"'|?v=__WASM_VERSION__|g" "${STAMP_FILES[@]}"' EXIT
+    echo ">>> Stamp will be reverted on EXIT (use --no-revert to keep it)"
+else
+    echo ">>> Stamp will be kept (--no-revert); files are ready for deploy"
+fi
 
 echo ">>> Done. Files:"
 ls -lh "${OUT_DIR}"


### PR DESCRIPTION
Closes #11.

## What

Adds a `--no-revert` flag to `scripts/build_wasm.bash` and
passes it from the deploy workflow. With the flag, the EXIT
trap that reverts the `?v=<version>` stamp back to the
`?v=__WASM_VERSION__` placeholder is skipped, so the stamped
files survive until `wrangler pages deploy` reads them.

## Why

The fix from #9 / #10 stamped the cache-bust into
`app.js` and `index.html` and registered an EXIT trap to
revert the stamp so local builds leave the working tree
clean. The trap fires when the build script exits, but the
deploy workflow runs the build script and the
`wrangler pages deploy` step **separately** in the same job.
The trap fires between the two steps, so the deploy reads
`app.js` / `index.html` with the placeholder, not the
version. After the merge of #10, both
`multiplication.rovisoft.net` and
`long-multiplication-calculator.pages.dev` shipped with
`?v=__WASM_VERSION__` in the served HTML / JS.

## Changes

- `scripts/build_wasm.bash`:
  - Argument parsing is now a small `for/case` loop with `-h` /
    `--help` printing the header comment.
  - New `--no-revert` flag: skips the EXIT trap, leaves the
    stamp in place for the next step (deploy) to read.
  - Default behaviour is unchanged: stamp + revert on EXIT.
- `.github/workflows/deploy.yml`: passes `--no-revert` to the
  build script.

## Verification

- `./scripts/build_wasm.bash` (default): the stamp is
  reverted; `git status` shows only the script + workflow
  changes (the `app.js` and `index.html` placeholders are
  preserved).
- `./scripts/build_wasm.bash --no-revert`: the stamp is kept;
  `grep '?v=2.1.0' web/asset/js/app.js web/index.html` shows
  the version-baked URLs.
- Full gauntlet:
  - `cargo fmt --all -- --check`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo test --workspace` (130/130 passing)
  - `cargo build --workspace --release`
  - `cargo doc --workspace --no-deps`
  - `cargo audit` (no advisories)
  - `wasm-pack test --chrome --headless crates/wasm` (1/1 in
    headless Chromium)

## Notes

- After this lands, the next deploy will (correctly) serve
  `?v=2.1.0` from both URLs. No further action is needed;
  the cache-bust is now actually live.
- The underlying zone-level cache rule on `rovisoft.net`
  (the original root cause we documented in #9) is still
  out of scope. This fix makes the app resilient to it.