### PR TITLE
docs(changelog): add missing 2.1.0 release entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ project adheres to [Semantic Versioning](https://semver.org/).
   running `scripts/build_wasm.bash`, so Cloudflare Pages deploys
   publish the optimised WASM bundle (the script silently skipped
   `wasm-opt` if the binary was missing).
+- The deploy workflow uses `cloudflare/wrangler-action@v3`,
+  picking up the maintained v3 line of the action.
+- The web front-end footer now displays the site and app version;
+  the app version is read from the WASM bundle's stamped metadata
+  so visitors can confirm they are running the latest build.
+- The WASM glue (`web/asset/js/wasm/`) is stamped with the
+  package version at build time, so browsers stop serving the
+  stale cached bundle after a new release.
 
 ### Fixed
 
@@ -55,6 +63,14 @@ project adheres to [Semantic Versioning](https://semver.org/).
   `13597_8642.txt` (the real filename is `13597_x_8642.txt`) and
   the doctest example invoked the removed `core::store` helper.
   Both are updated to match the current codebase.
+- The WASM cache-bust stamp is propagated as a build artifact
+  into the deploy job, so Cloudflare Pages always uploads a
+  versioned bundle even when the deploy step runs on a fresh
+  checkout.
+- `actions/checkout` is bumped to v5 (Node 20 runtime) in both
+  CI workflows.
+- `scripts/build_wasm.sh` is renamed to `scripts/build_wasm.bash`
+  to match the script-naming convention referenced in `AGENTS.md`.
 
 ## [2.0.0] - 2026-06-16
 


### PR DESCRIPTION
## Summary

The first pass at the `## [2.1.0] - 2026-06-16` entry in `CHANGELOG.md`
covered the headline breaking changes and the most visible fixes, but
missed a handful of items that landed in the same release. This PR
adds them to the 2.1.0 section so the changelog matches what v2.1.0
actually shipped.

## Items added

**Added**
- The deploy workflow uses `cloudflare/wrangler-action@v3`.
- The web front-end footer now displays the site and app version.
- The WASM glue is stamped with the package version at build time so
  browsers stop serving the stale cached bundle after a new release.

**Fixed**
- The WASM cache-bust stamp is propagated as a build artifact into the
  deploy job, so Cloudflare Pages always uploads a versioned bundle
  even when the deploy step runs on a fresh checkout.
- `actions/checkout` is bumped to v5 (Node 20 runtime) in both CI
  workflows.
- `scripts/build_wasm.sh` is renamed to `scripts/build_wasm.bash` to
  match the script-naming convention in `AGENTS.md`.

## Why now

The `v2.1.0` git tag was published pointing at `d41badc` before this
gap was noticed. The tag itself remains valid (and continues to point
at `d41badc`); this change is a descendant commit, so release artefacts
already shipped (e.g. the Cloudflare Pages deploy triggered by the
tag) are unaffected. Adding the missing entries to the changelog now
keeps the v2.1.0 release notes complete for anyone who consults them
later, including consumers diffing the byte-for-byte output and any
future `gh release create v2.1.0` we might add.

## Out of scope

- Pure-docs commits (`dadab64`, `a185339`, `33a114a`) are intentionally
  omitted from the release notes per the convention used elsewhere in
  this CHANGELOG.

Closes #13