### PR TITLE
ci(workflow): bump third-party actions to latest major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: wasm-pack test --chrome --headless crates/wasm
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-pkg
           path: crates/wasm/pkg

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./scripts/build_wasm.bash --no-revert
 
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Bumps two third-party GitHub Actions that were behind the latest stable major.

## What changed

- `.github/workflows/ci.yml`: `actions/upload-artifact` v4 -> v7
- `.github/workflows/deploy.yml`: `cloudflare/wrangler-action` v3 -> v4

Other actions in the repo (`actions/checkout@v5`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`) are already on the latest major / a floating tag and are left untouched. Both bumps keep the existing floating-major convention (`@v7`, `@v4`), not a pinned patch version.

## Why

- **actions/upload-artifact v7**: v4 is no longer the latest stable major. v7 adds direct (unzipped) file uploads, switches the action to ESM, and runs on Node.js 24, picking up all the cumulative fixes since v4.
- **cloudflare/wrangler-action v4**: v3 still works, but v4 now defaults the installed Wrangler CLI to the Wrangler v4 line, which is the actively maintained major of Wrangler itself. The inputs/outputs used by this workflow (apiToken, accountId, command, gitHubToken) are unchanged.

## How it was verified

- Branched off `main` (the default branch).
- Single GPG-signed commit (`e3f50a3`, signature `G` = good on the local and the remote).
- `actionlint` (`/tmp/opencode/bin/actionlint`) passes with no errors on both modified workflow files.
- No other workflow files were modified.
- CI will run on the PR; the deploy workflow is `workflow_dispatch`-only, so the wrangler-action bump is verified via actionlint + the v3->v4 input/output compatibility noted above.