### PR TITLE
ci(workflow): bump actions/checkout to v7 in ci and deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Lint, test, build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -51,7 +51,7 @@ jobs:
     name: Build WASM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build WASM and deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Follow-up to #15.

## What changed

- `actions/checkout@v5` → `@v7` in `.github/workflows/ci.yml` (two jobs) and `.github/workflows/deploy.yml`

## Why

PR #15's regex-based scan missed the `- uses: actions/checkout@v5` lines because they use a YAML list-item form that the first scan's pattern didn't catch. v5 is on a Node 20 runtime; v7 is the current major. Bumping it to v7 keeps the repo on a single major for checkout across all workflows. The input surface used here is unchanged (no `with:` block in any of the three steps).

## Verification

- [x] actionlint clean
- [x] Commit is GPG-signed
- [x] Branched off the default branch (`main`)